### PR TITLE
perf: move top of the execution stack instead of copy

### DIFF
--- a/narivm.cpp
+++ b/narivm.cpp
@@ -477,7 +477,7 @@ vector<Command> split_lines(const string &code)
 
 void push(Value v)
 {
-    execution_stack.push(v);
+    execution_stack.push(std::move(v));
 }
 
 Value pop(Command &command)

--- a/narivm.cpp
+++ b/narivm.cpp
@@ -486,7 +486,7 @@ Value pop(Command &command)
     {
         raise_nvm_error("Execution stack empty for command: " + command.get_debug_string());
     }
-    Value v = execution_stack.top();
+    auto v = std::move(execution_stack.top());
     execution_stack.pop();
     return v;
 }


### PR DESCRIPTION
Reduces time to run benchmark from ~22" to ~13.5" on my M1.
