### PR TITLE
perf: reduce copies on get/set_variable

### DIFF
--- a/narivm.cpp
+++ b/narivm.cpp
@@ -502,7 +502,7 @@ void set_variable(const string &var_name, Value value)
     {
         add_scope();
     }
-    variable_tables[variable_tables.size() - 1][var_name] = value;
+    variable_tables[variable_tables.size() - 1][var_name] = std::move(value);
 }
 
 void delete_variable(const string &name)
@@ -538,7 +538,7 @@ void set_global_variable(const string &var_name, Value value)
     variable_tables[0][var_name] = value;
 }
 
-Value get_variable(const string &var_name)
+const Value &get_variable(const string &var_name)
 {
     if (!variable_tables.empty())
     {
@@ -552,7 +552,9 @@ Value get_variable(const string &var_name)
             return variable_tables[0][var_name];
         }
     }
-    return get_nil_value();
+    static Value nil_value;
+    nil_value.set_nil_value(); // Refresh the nil just in case
+    return nil_value;
 }
 
 string substring(const string &s, long long from, long long count)


### PR DESCRIPTION
Another ~12% improvement.
```
(kat) pelito@MacBook-Pro-7 katalyn % hyperfine -N -r 5 "./narivm_new ./bench.nvm" "./narivm_old ./bench.nvm"
Benchmark 1: ./narivm_new ./bench.nvm
  Time (mean ± σ):      7.352 s ±  0.324 s    [User: 6.858 s, System: 0.425 s]
  Range (min … max):    6.980 s …  7.654 s    5 runs
 
Benchmark 2: ./narivm_old ./bench.nvm
  Time (mean ± σ):      8.266 s ±  0.515 s    [User: 7.759 s, System: 0.364 s]
  Range (min … max):    7.779 s …  9.006 s    5 runs
 
Summary
  ./narivm_new ./bench.nvm ran
    1.12 ± 0.09 times faster than ./narivm_old ./bench.nvm
```