### PR TITLE
feat: add support for standalone binaries

### DIFF
--- a/compile_nvm_standalone.sh
+++ b/compile_nvm_standalone.sh
@@ -1,0 +1,19 @@
+set -e
+
+optimization="-O1"
+
+# Compile the NariVM
+echo "Compiling NariVM"
+g++ -c -o user_code.o user_code.S
+g++ -std=c++17 narivm.cpp -c -o narivm.o $optimization
+
+echo "Building Tiny Process Library"
+processdir="tiny-process-library"
+g++ -std=c++17 "$processdir/process.cpp" -c -o process.o $optimization
+g++ -std=c++17 "$processdir/process_unix.cpp" -c -o process_unix.o $optimization
+
+echo "Linking NariVM"
+g++ -std=c++17 narivm.o process.o process_unix.o user_code.o -o narivm_program -pthread
+
+echo "Cleaning up"
+rm *.o

--- a/narivm.cpp
+++ b/narivm.cpp
@@ -38,6 +38,8 @@ using namespace TinyProcessLib;
 size_t pc = 0; // Program Counter
 void raise_nvm_error(string error_message);
 
+extern const char __attribute__((weak)) user_code[] = "";
+
 string get_type_name(char type)
 {
     switch (type)
@@ -2166,14 +2168,17 @@ void read_source(string filename, string &output)
 
 int main(int argc, char *argv[])
 {
-    vector<string> args(argv, argv + argc);
-    if (args.size() != 2)
+    string code = user_code;
+    if (code.empty())
     {
-        cerr << "Usage: narivm <nambly_file>" << endl;
-        exit(1);
+        vector<string> args(argv, argv + argc);
+        if (args.size() != 2)
+        {
+            cerr << "Usage: narivm <nambly_file>" << endl;
+            exit(1);
+        }
+        read_source(argv[1], code);
     }
-    string code;
-    read_source(argv[1], code);
     // cout << code << endl;
     vector<Command> code_listing = generate_label_map_and_code_listing(code);
     // print_command_listing(code_listing);

--- a/user_code.S
+++ b/user_code.S
@@ -1,0 +1,4 @@
+.global _user_code
+_user_code:
+    .incbin "user_code.nvm"
+    .byte 0


### PR DESCRIPTION
This enables distribution of standalone programs based on the NariVM.
It uses a neat assembly trick to include the text of a compiled NariVM
program, which MUST be named `user_code.nvm` and then links it as a
weak symbol in NariVM. If the text is not an empty string, then it is
a bundle and directly runs the bundled code.

To create such a standalone program:
1. Compile your code with `kat.py -i demo.kat > demo.nvm`
2. Rename your compiled code: `cp demo.nvm user_code.nvm`
3. Run the `compile_nvm_standalone.sh` script
